### PR TITLE
Allow for ⍬ in expect and nexpect values.

### DIFF
--- a/UT.dyalog
+++ b/UT.dyalog
@@ -291,9 +291,9 @@
     ∇
 
     ∇ reset_UT_globals
-      expect←⍬
+      expect_orig ← expect← ⎕NS⍬
       exception←⍬
-      nexpect←⍬
+      nexpect_orig ← nexpect← ⎕NS⍬
     ∇
 
     ∇ Z←is_test FunctionName;wsIndex


### PR DESCRIPTION
This fixes an issue where `expect` and `nexpect` cannot have `⍬` used as a valid expected value. 
