### PR TITLE
Give better printed behavior with more knobs

### DIFF
--- a/UT.dyalog
+++ b/UT.dyalog
@@ -6,6 +6,8 @@
     exception ← ⍬
     nexpect_orig ← nexpect ← ⎕NS⍬
     print_passed ← 1
+    print_summary ← 1
+    print_header ← 0
 
     ∇ {Z}←{Conf}run Argument;PRE_test;POST_test;TEST_step;COVER_step;FromSpace
      
@@ -78,7 +80,9 @@
       t←⎕TS
       Z←run_ut¨{FromSpace ⍵}¨ListOfNames
       t←⎕TS-t
-      ('Test execution report')print_passed_crashed_failed Z t
+      :If print_summary
+          ('Test execution report')print_passed_crashed_failed Z t
+      :EndIf
     ∇
 
     ∇ Z←FromSpace file_test_function FilePath;FileNS;Functions;TestFunctions;t
@@ -89,19 +93,35 @@
           ⎕←'No test functions found'
           Z←⍬
       :Else
+          :If print_header
+              ⎕←'Testing from ',FilePath
+          :EndIf
           t←⎕TS
           Z←run_ut¨{FileNS ⍵}¨TestFunctions
           t←⎕TS-t
-          (FilePath,' tests')print_passed_crashed_failed Z t
+          :If print_summary
+              (FilePath,' tests')print_passed_crashed_failed Z t
+          :EndIf
       :EndIf
     ∇
 
-    ∇ Z←FromSpace test_dir_function Test_files
+    ∇ Z←FromSpace test_dir_function Test_files;old_sum;old_head
       :If Test_files≡⍬/⍬,⊂''
           ⎕←'No test files found'
           Z←⍬
       :Else
+          old_sum←print_summary
+          old_head←print_header
+          print_summary←0
+          print_header←1
+          t←⎕TS
           Z←#.UT.run¨Test_files
+          t←⎕TS-t
+          print_summary←old_sum
+          print_header←old_head
+          :If print_summary
+              'All tests'print_passed_crashed_failed (⊃,/Z)t
+          :EndIf
       :EndIf
     ∇
 

--- a/UT.dyalog
+++ b/UT.dyalog
@@ -5,6 +5,7 @@
     expect_orig ← expect ← ⎕NS⍬
     exception ← ⍬
     nexpect_orig ← nexpect ← ⎕NS⍬
+    print_passed ← 1
 
     ∇ {Z}←{Conf}run Argument;PRE_test;POST_test;TEST_step;COVER_step;FromSpace
      
@@ -262,7 +263,7 @@
       (returned crashed time)←execute_function ut_data
       (pass crash fail)←determine_pass_crash_or_fail returned crashed
       message←determine_message pass fail crashed(2⊃ut_data)returned time
-      print_message_to_screen message
+      (pass∧~crashed)print_message_to_screen message
       Z←(pass crash fail)
     ∇
 
@@ -327,8 +328,10 @@
       :EndIf
     ∇
 
-    ∇ print_message_to_screen message
-      ⎕←message
+    ∇ passed print_message_to_screen message
+      :If (~passed)∨passed∧print_passed
+          ⎕←message
+      :EndIf
     ∇
 
     ∇ Z←term_to_text Term;Text;Rows

--- a/UT.dyalog
+++ b/UT.dyalog
@@ -1,5 +1,6 @@
 ﻿:NameSpace UT
 
+    ⎕IO ← 1
     sac ← 0
     expect_orig ← expect ← ⎕NS⍬
     exception ← ⍬


### PR DESCRIPTION
It is often useful not to use screen real estate to print out the passed tests as well as the failing ones. This pull request enables this by creating a global setting `print_passed` that can be used to disable printing of passed tests.