### PR TITLE
Print the name of the test when it is passed.

### DIFF
--- a/UT.dyalog
+++ b/UT.dyalog
@@ -342,7 +342,7 @@
       :If crashed
           Z←'CRASHED: 'failure_message name returned
       :ElseIf pass
-          Z←'Passed ',time[5],'m',time[6],'s',time[7],'ms'
+          Z←name,' Passed ',time[5],'m',time[6],'s',time[7],'ms'
       :Else
           Z←'FAILED: 'failure_message name returned
       :EndIf


### PR DESCRIPTION
It is very helpful to see the name of the test when it passes so that long running test sequences, if they cause a crash or some other failure, can be traced back to the offending test more easily, in cases where the system's test suite may go down. 